### PR TITLE
Document standard stack and add stack-setup skill

### DIFF
--- a/.claude/hooks/context-v8.py
+++ b/.claude/hooks/context-v8.py
@@ -32,7 +32,7 @@ def main():
 
     # Stacks
     stacks = {
-        "web": "Convex+Next.js+Clerk->Vercel",
+        "web": "Astro+CF-Pages/Workers+BetterAuth+Postgres",
         "cli": "Python+Click+SQLite",
         "svc": "Python+systemd->oci"
     }

--- a/.claude/infrastructure/STACK.md
+++ b/.claude/infrastructure/STACK.md
@@ -1,0 +1,267 @@
+# Omar's Standard Stack
+
+## Overview
+
+Every project uses this stack unless there's a good reason not to:
+
+```
+[Local Dev]
+    ↓ git push
+[Cloudflare Pages] ← static frontend (Astro)
+    ↓
+[Cloudflare Workers] ← serverless API
+    ↓
+[Cloudflare Hyperdrive] ← connection pooler + query cache
+    ↓
+[Postgres on OCI] ← data (self-hosted, free forever)
+```
+
+**Why this stack:**
+- $0 cost (Cloudflare free tier + OCI free tier)
+- No vendor lock-in on data (Postgres is yours)
+- Fast (edge compute + cached queries)
+- Simple (Astro + Workers + SQL)
+- LLM-friendly (every AI knows this stack)
+
+---
+
+## Database
+
+### Connection Info
+
+**Host:** `100.126.13.70` (Tailscale IP - only accessible from Tailscale network)
+**Port:** `5432`
+**User:** `omar`
+**Password:** See `~/pg-server/.env` on OCI box
+
+**Connection string format:**
+```
+postgresql://omar:PASSWORD@100.126.13.70:5432/DATABASE_NAME
+```
+
+### Common Operations
+
+**Create new database for a project:**
+```bash
+# From any machine on Tailscale
+ssh ubuntu@100.126.13.70 "docker exec pg-server createdb -U omar project_name"
+
+# Or if already on OCI
+docker exec pg-server createdb -U omar project_name
+```
+
+**List all databases:**
+```bash
+docker exec pg-server psql -U omar -c "\l"
+```
+
+**Access psql directly:**
+```bash
+docker exec -it pg-server psql -U omar -d database_name
+```
+
+**Run a SQL file:**
+```bash
+docker exec -i pg-server psql -U omar -d database_name < schema.sql
+```
+
+**Backup all databases:**
+```bash
+cd ~/pg-server && ./backup.sh
+```
+
+**Backup single database:**
+```bash
+docker exec pg-server pg_dump -U omar database_name > backup.sql
+```
+
+---
+
+## Cloudflare Tunnel (Already Configured)
+
+The tunnel connects Cloudflare's network to the Postgres instance on OCI without exposing it to the public internet.
+
+**Tunnel hostname:** `pg.omarsnewgroove.com` (or check `~/.cloudflared/config.yml` on OCI)
+
+**Status check:**
+```bash
+ssh ubuntu@100.126.13.70 "sudo systemctl status cloudflared"
+```
+
+**If tunnel needs restart:**
+```bash
+ssh ubuntu@100.126.13.70 "sudo systemctl restart cloudflared"
+```
+
+---
+
+## Per-Project Setup
+
+### 1. Create the Database
+
+```bash
+docker exec pg-server createdb -U omar my_project
+```
+
+### 2. Set Up Hyperdrive
+
+```bash
+# One-time per project
+npx wrangler hyperdrive create my-project-db \
+  --connection-string="postgresql://omar:PASSWORD@pg.omarsnewgroove.com:5432/my_project"
+```
+
+Save the ID it returns.
+
+### 3. Configure wrangler.toml
+
+```toml
+name = "my-project"
+main = "src/worker.ts"
+compatibility_date = "2024-01-01"
+
+[[hyperdrive]]
+binding = "HYPERDRIVE"
+id = "your-hyperdrive-id-here"
+```
+
+### 4. Use in Worker Code
+
+```typescript
+import postgres from 'postgres'
+
+export interface Env {
+  HYPERDRIVE: Hyperdrive
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const sql = postgres(env.HYPERDRIVE.connectionString)
+
+    const users = await sql`SELECT * FROM users WHERE active = true`
+
+    return Response.json(users)
+  }
+}
+```
+
+### 5. Astro + Cloudflare Adapter
+
+```bash
+npx astro add cloudflare
+```
+
+In `astro.config.mjs`:
+```javascript
+import { defineConfig } from 'astro/config'
+import cloudflare from '@astrojs/cloudflare'
+
+export default defineConfig({
+  output: 'server',
+  adapter: cloudflare()
+})
+```
+
+---
+
+## Local Development
+
+For local dev, connect directly via Tailscale (no Hyperdrive needed):
+
+**.env.local:**
+```
+DATABASE_URL=postgresql://omar:PASSWORD@100.126.13.70:5432/my_project
+```
+
+**In code, handle both environments:**
+```typescript
+const connectionString = env.HYPERDRIVE?.connectionString || process.env.DATABASE_URL
+const sql = postgres(connectionString)
+```
+
+---
+
+## Project Structure (Astro + Workers)
+
+```
+my-project/
+├── src/
+│   ├── pages/           # Astro pages
+│   ├── components/      # UI components
+│   ├── layouts/         # Page layouts
+│   └── lib/
+│       └── db.ts        # Database client
+├── functions/           # Cloudflare Workers (if separate from Astro)
+├── public/              # Static assets
+├── astro.config.mjs
+├── wrangler.toml        # Cloudflare config
+├── .env.local           # Local dev (gitignored)
+├── .env.example         # Template for others
+└── package.json
+```
+
+---
+
+## Deployment
+
+**Deploy to Cloudflare Pages:**
+```bash
+npm run build
+npx wrangler pages deploy dist
+```
+
+**Or connect GitHub for auto-deploy:**
+1. Go to Cloudflare Dashboard → Pages
+2. Connect repository
+3. Build command: `npm run build`
+4. Output directory: `dist`
+
+---
+
+## Backups
+
+**Automated (cron on OCI):**
+```bash
+# Add to crontab: crontab -e
+0 3 * * * cd ~/pg-server && ./backup.sh
+```
+
+**Manual backup:**
+```bash
+ssh ubuntu@100.126.13.70 "cd ~/pg-server && ./backup.sh"
+```
+
+**Backup location:** `~/pg-server/backups/` on OCI (7-day retention)
+
+---
+
+## Troubleshooting
+
+### Can't connect to database
+1. Check Tailscale is connected: `tailscale status`
+2. Check Postgres is running: `ssh oci "docker ps | grep pg-server"`
+3. Check credentials: `ssh oci "cat ~/pg-server/.env"`
+
+### Hyperdrive not working
+1. Verify tunnel is running: `ssh oci "sudo systemctl status cloudflared"`
+2. Check Hyperdrive config: `npx wrangler hyperdrive list`
+3. Test direct connection first before debugging Hyperdrive
+
+### Worker can't reach database
+1. Confirm Hyperdrive binding in wrangler.toml
+2. Check you're using `env.HYPERDRIVE.connectionString`
+3. Verify the Hyperdrive ID matches
+
+---
+
+## Cost
+
+| Component | Cost |
+|-----------|------|
+| Cloudflare Pages | Free (unlimited sites) |
+| Cloudflare Workers | Free (100k requests/day) |
+| Cloudflare Hyperdrive | Free tier available |
+| Cloudflare Tunnel | Free |
+| OCI Compute | Free tier (ARM, 24GB RAM) |
+| Postgres | Free (self-hosted) |
+| **Total** | **$0** |

--- a/.claude/infrastructure/STACK.md
+++ b/.claude/infrastructure/STACK.md
@@ -254,6 +254,53 @@ ssh ubuntu@100.126.13.70 "cd ~/pg-server && ./backup.sh"
 
 ---
 
+## Authentication
+
+### Default: Better Auth + Google OAuth
+
+**Better Auth** is the default auth library. Sessions stored in your Postgres.
+
+**Install:**
+```bash
+npm install better-auth
+```
+
+**Setup `src/lib/auth.ts`:**
+```typescript
+import { betterAuth } from 'better-auth'
+import postgres from 'postgres'
+
+const sql = postgres(process.env.DATABASE_URL!)
+
+export const auth = betterAuth({
+  database: sql,
+  socialProviders: {
+    google: {
+      clientId: process.env.GOOGLE_CLIENT_ID!,
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
+    },
+  },
+})
+```
+
+**Google OAuth setup:**
+1. Go to [Google Cloud Console](https://console.cloud.google.com/apis/credentials)
+2. Create OAuth 2.0 Client ID
+3. Set redirect URI: `https://your-site.pages.dev/api/auth/callback/google`
+4. Add `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` to `.env.local`
+
+**Environment variables needed:**
+```
+GOOGLE_CLIENT_ID=your-client-id
+GOOGLE_CLIENT_SECRET=your-client-secret
+```
+
+### Internal Tools: Cloudflare Access
+
+For admin dashboards and internal tools, use Cloudflare Access (already configured). No code needed — just toggle on in the Cloudflare dashboard.
+
+---
+
 ## Cost
 
 | Component | Cost |
@@ -264,4 +311,6 @@ ssh ubuntu@100.126.13.70 "cd ~/pg-server && ./backup.sh"
 | Cloudflare Tunnel | Free |
 | OCI Compute | Free tier (ARM, 24GB RAM) |
 | Postgres | Free (self-hosted) |
+| Better Auth | Free (open-source) |
+| Cloudflare Access | Free (50 users) |
 | **Total** | **$0** |

--- a/.claude/rules/README.md
+++ b/.claude/rules/README.md
@@ -5,7 +5,7 @@
 Rules are split into:
 - **core.md** - Always loaded (~150 lines)
 - **khamel-mode.md** - User-specific defaults (~50 lines)
-- **web.md** - Web app rules (Convex + Next.js)
+- **web.md** - Web app rules (Astro + Cloudflare + Better Auth + Postgres)
 - **cli.md** - CLI rules (Python + Click)
 - **service.md** - Service/API rules (Python + systemd)
 
@@ -24,7 +24,7 @@ Claude should auto-detect project type from files:
 
 | Detection | Project Type | Rules Loaded |
 |-----------|--------------|--------------|
-| `package.json` + `convex/` | Web app | core + khamel-mode + web |
+| `astro.config.*` or `wrangler.toml` | Web app | core + khamel-mode + web |
 | `setup.py` or `pyproject.toml` | CLI | core + khamel-mode + cli |
 | `*.service` systemd file | Service | core + khamel-mode + service |
 | No detection | Generic | core + khamel-mode |
@@ -44,7 +44,7 @@ In your project's `CLAUDE.md`:
 
 Auto-detect project type and load appropriate rules.
 
-If this is a **web app** (Convex + Next.js): Use web defaults
+If this is a **web app** (Astro + Cloudflare): Use web defaults
 If this is a **CLI** (Python + Click): Use CLI defaults
 If this is a **service** (Python + systemd): Use service defaults
 

--- a/.claude/rules/cli.md
+++ b/.claude/rules/cli.md
@@ -13,7 +13,7 @@ Python + Click + SQLite
 Detect by presence of:
 - `setup.py` or `pyproject.toml`
 - CLI entry points defined
-- No `convex/` or web framework files
+- No `astro.config.*` or `wrangler.toml` or web framework files
 
 ## Click-Specific Rules
 

--- a/.claude/rules/khamel-mode.md
+++ b/.claude/rules/khamel-mode.md
@@ -2,31 +2,40 @@
 
 When building ANYTHING for this user, assume these defaults without asking.
 
-## Infrastructure (Brain/Body/Muscle Model)
+## Infrastructure
 
 | Machine | Tailscale IP | Role |
 |---------|--------------|------|
-| **oci-dev** | 100.126.13.70 | Services, Claude Code, OCI resources |
-| **homelab** | 100.112.130.100 | Docker services, 26TB storage, persistent data |
-| **macmini** | 100.113.216.27 | Apple Silicon GPU, transcription, video/audio |
+| **oci-dev** | 100.126.13.70 | Primary dev, services, Postgres, Claude Code |
+| **homelab** | 100.112.130.100 | Personal local infra, 26TB storage |
+| **macmini** | 100.113.216.27 | Apple Silicon GPU, tasks needing throughput |
 
 - **Networking**: All machines on Tailscale (deer-panga.ts.net)
-- **Public access**: Tailscale Funnel + poytz → khamel.com (NOT nginx/traefik)
+- **Public access**: Cloudflare Tunnel + Cloudflare Pages (NOT nginx/traefik)
+- **Internal tools**: Cloudflare Access (already configured)
 - **Secrets**: SOPS/Age, decrypt from `~/github/oneshot/secrets/`
 
 ## Stack Defaults (Don't Ask, Just Use)
 
 | Project Type | Default Stack |
 |--------------|---------------|
-| Web apps | Convex + Next.js + Clerk → Vercel |
+| Web apps | Astro + Cloudflare Pages/Workers + Better Auth + Postgres on OCI |
 | CLIs | Python + Click + SQLite |
 | Services/APIs | Python + systemd → oci-dev |
-| Heavy compute | Route to macmini |
+| Heavy compute / throughput | Route to macmini |
 | Large storage | Route to homelab (26TB) |
+
+**Full stack docs**: `.claude/infrastructure/STACK.md`
 
 ## Storage Progression
 ```
-SQLite (default) → Convex (web apps) → OCI Autonomous DB (>20GB/multi-user)
+SQLite (default for CLIs) → Postgres on OCI (web apps, services) → OCI Autonomous DB (>20GB/multi-user)
+```
+
+## Auth Default
+```
+Better Auth + Google OAuth → sessions in Postgres
+Cloudflare Access → internal/admin tools (already configured)
 ```
 
 ## Tool Enforcement
@@ -35,10 +44,12 @@ SQLite (default) → Convex (web apps) → OCI Autonomous DB (>20GB/multi-user)
 - **ALWAYS** check lessons before debugging
 
 ## Anti-Patterns to Flag
-- nginx/traefik → Use Tailscale Funnel + poytz
-- postgres/mysql/mongodb → Default is SQLite → Convex → OCI DB
-- express/fastapi/flask for web → Convex handles the backend
+- nginx/traefik → Use Cloudflare Tunnel / Cloudflare Pages
+- mysql/mongodb → Default is SQLite (CLIs) or Postgres on OCI (web/services)
+- express/fastapi/flask for web → Cloudflare Workers handles the API
+- Convex/Next.js/Clerk/Vercel → Old stack, use Astro + CF + Better Auth + Postgres
 - aws/gcp/azure → Default is OCI free tier or homelab
+- Lucia auth → Deprecated, use Better Auth
 
 ## When You Notice Drift
 If Claude notices we're NOT using beads, Tailscale, ONE_SHOT patterns, or standard stack:

--- a/.claude/rules/web.md
+++ b/.claude/rules/web.md
@@ -1,41 +1,59 @@
-# Web App Rules (Convex + Next.js + Clerk)
+# Web App Rules (Astro + Cloudflare + Better Auth + Postgres)
 
 ## Default Stack
 
 When building web apps for this user:
 
 ```
-Convex (backend) + Next.js (frontend) + Clerk (auth) → Deploy to Vercel
+Astro (frontend) + Cloudflare Workers (API) + Better Auth (auth) + Postgres on OCI (data)
+Deploy to: Cloudflare Pages
 ```
 
 ## When to Use
 
 Detect by presence of:
-- `package.json` with `convex` dependency
-- `convex/` directory
-- `app/` or `pages/` directory
+- `astro.config.mjs` or `astro.config.ts`
+- `wrangler.toml`
+- `package.json` with `astro` dependency
 
-## Convex-Specific Rules
+## Astro-Specific Rules
 
-- **Backend is Convex** - Don't suggest Express, FastAPI, or custom backends
-- **File-based routing** - Use `convex/schema.ts` for data model
-- **Real-time by default** - Leverage Convex subscriptions
-- **Auth via Clerk** - Don't build custom auth
+- **Astro is the framework** - Don't suggest Next.js, Remix, SvelteKit
+- **Cloudflare adapter** - Use `@astrojs/cloudflare` for SSR
+- **Islands architecture** - Server-first, add interactivity with client directives
+- **Content Collections** - Use for structured content when applicable
 
-## Next.js-Specific Rules
+## Cloudflare Workers Rules
 
-- **App Router preferred** - Use `app/` directory over `pages/`
-- **Server Components** - Default to RSC, use Client Components sparingly
-- **API Routes via Convex** - Don't use Next.js API routes, use Convex functions
+- **API via Workers** - Don't suggest Express, FastAPI, or standalone API servers
+- **Hyperdrive** - Use for Postgres connection pooling in production
+- **wrangler.toml** - All deployment config lives here
+- **Local dev** - Connect directly to Postgres via Tailscale (no Hyperdrive needed)
+
+## Auth Rules
+
+- **Better Auth** - Default auth library, don't suggest Clerk, Auth0, or NextAuth
+- **Google OAuth** - Default provider via Better Auth
+- **Sessions in Postgres** - Auth data lives in your database, you own it
+- **Cloudflare Access** - Use for internal/admin tools only
+
+## Database Rules
+
+- **Postgres on OCI** - Default database for all web apps
+- **Direct Tailscale connection** - For local dev (100.126.13.70:5432)
+- **Hyperdrive** - For production (via Cloudflare Tunnel)
+- **`postgres` npm package** - Use this, not pg/knex/prisma/drizzle unless needed
 
 ## Deployment
 
-- **Vercel** - Default deploy target, no configuration needed
-- **Convex dashboard** - `npx convex dev` for local development
+- **Cloudflare Pages** - Default deploy target
+- **GitHub auto-deploy** - Connect repo in CF dashboard
+- **Manual**: `npm run build && npx wrangler pages deploy dist`
 
 ## Anti-Patterns
 
-- ❌ Don't suggest PostgreSQL, MongoDB, or other databases
-- ❌ Don't suggest custom authentication
-- ❌ Don't suggest API routes (use Convex functions)
-- ❌ Don't suggest server-side frameworks (Express, FastAPI)
+- ❌ Don't suggest Convex, Next.js, Clerk, or Vercel (old stack)
+- ❌ Don't suggest MongoDB, MySQL, or other databases
+- ❌ Don't suggest Lucia auth (deprecated)
+- ❌ Don't suggest standalone API servers (Express, FastAPI)
+- ❌ Don't suggest heavy ORMs (Prisma, Drizzle) unless explicitly needed

--- a/.claude/skills/stack-setup/SKILL.md
+++ b/.claude/skills/stack-setup/SKILL.md
@@ -1,0 +1,185 @@
+# Stack Setup Skill
+
+Configure a project to use Omar's standard Cloudflare + Postgres stack.
+
+## Triggers
+
+Activate this skill when the user says:
+- "set up cloudflare"
+- "add database" / "add postgres" / "need a database"
+- "configure for deploy"
+- "set up the stack"
+- "make this deployable"
+- "push to cloud" (if no deployment config exists)
+
+## Prerequisites
+
+Before running this skill, verify:
+1. Cloudflare Tunnel is running on OCI (`pg.omarsnewgroove.com` resolves)
+2. User has `wrangler` CLI authenticated (`npx wrangler whoami`)
+3. Postgres is running (`docker exec pg-server psql -U omar -c "SELECT 1"`)
+
+## Actions
+
+### 1. Read Infrastructure Docs
+
+```
+Read .claude/infrastructure/STACK.md for connection details and patterns.
+```
+
+### 2. Create Database
+
+```bash
+# Ask user for project/database name if not obvious from context
+docker exec pg-server createdb -U omar PROJECT_NAME
+```
+
+### 3. Create Schema File
+
+Create `schema.sql` with initial tables based on project requirements:
+
+```sql
+-- schema.sql
+-- Run with: docker exec -i pg-server psql -U omar -d PROJECT_NAME < schema.sql
+
+CREATE TABLE IF NOT EXISTS users (
+    id SERIAL PRIMARY KEY,
+    email TEXT UNIQUE NOT NULL,
+    created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Add project-specific tables
+```
+
+### 4. Set Up Hyperdrive
+
+```bash
+npx wrangler hyperdrive create PROJECT_NAME-db \
+  --connection-string="postgresql://omar:PASSWORD@pg.omarsnewgroove.com:5432/PROJECT_NAME"
+```
+
+Capture the returned ID for wrangler.toml.
+
+### 5. Create/Update wrangler.toml
+
+```toml
+name = "PROJECT_NAME"
+main = "src/worker.ts"  # or appropriate entry point
+compatibility_date = "2024-01-01"
+
+[[hyperdrive]]
+binding = "HYPERDRIVE"
+id = "HYPERDRIVE_ID_FROM_STEP_4"
+
+[vars]
+ENVIRONMENT = "production"
+```
+
+### 6. Add Astro Cloudflare Adapter (if Astro project)
+
+```bash
+npx astro add cloudflare
+```
+
+Update `astro.config.mjs`:
+```javascript
+import { defineConfig } from 'astro/config'
+import cloudflare from '@astrojs/cloudflare'
+
+export default defineConfig({
+  output: 'server',
+  adapter: cloudflare()
+})
+```
+
+### 7. Create Database Client
+
+Create `src/lib/db.ts`:
+
+```typescript
+import postgres from 'postgres'
+
+export function createClient(env: { HYPERDRIVE?: Hyperdrive }) {
+  const connectionString = env.HYPERDRIVE?.connectionString || process.env.DATABASE_URL
+
+  if (!connectionString) {
+    throw new Error('No database connection string available')
+  }
+
+  return postgres(connectionString)
+}
+
+// Type helper for Hyperdrive
+export interface Env {
+  HYPERDRIVE: Hyperdrive
+}
+```
+
+### 8. Create Environment Files
+
+**.env.example:**
+```
+# Local development (connect via Tailscale)
+DATABASE_URL=postgresql://omar:YOUR_PASSWORD@100.126.13.70:5432/PROJECT_NAME
+```
+
+**.env.local** (gitignored):
+```
+DATABASE_URL=postgresql://omar:ACTUAL_PASSWORD@100.126.13.70:5432/PROJECT_NAME
+```
+
+### 9. Update .gitignore
+
+Ensure these are ignored:
+```
+.env
+.env.local
+.env.*.local
+.wrangler/
+node_modules/
+dist/
+```
+
+### 10. Install Dependencies
+
+```bash
+npm install postgres
+```
+
+### 11. Test Connection
+
+Create a simple test:
+```typescript
+// test-db.ts
+import postgres from 'postgres'
+
+const sql = postgres(process.env.DATABASE_URL!)
+
+async function test() {
+  const result = await sql`SELECT NOW() as time`
+  console.log('Connected! Server time:', result[0].time)
+  await sql.end()
+}
+
+test().catch(console.error)
+```
+
+Run: `npx tsx test-db.ts`
+
+## Output Checklist
+- [ ] Database created on pg-server
+- [ ] schema.sql with initial tables
+- [ ] wrangler.toml with Hyperdrive configured
+- [ ] Astro cloudflare adapter (if applicable)
+- [ ] src/lib/db.ts client
+- [ ] .env.example and .env.local
+- [ ] Updated .gitignore
+- [ ] postgres package installed
+- [ ] Verified database connection
+
+## Notes
+
+- Always use the Tailscale IP (100.126.13.70) for local dev
+- Always use the tunnel hostname (pg.omarsnewgroove.com) for Hyperdrive
+- Password is in `~/pg-server/.env` on OCI - never commit it
+- Test locally before deploying to catch connection issues early

--- a/.claude/skills/stack-setup/SKILL.md
+++ b/.claude/skills/stack-setup/SKILL.md
@@ -140,13 +140,39 @@ node_modules/
 dist/
 ```
 
-### 10. Install Dependencies
+### 10. Set Up Better Auth
 
-```bash
-npm install postgres
+Create `src/lib/auth.ts`:
+```typescript
+import { betterAuth } from 'better-auth'
+import postgres from 'postgres'
+
+const sql = postgres(process.env.DATABASE_URL!)
+
+export const auth = betterAuth({
+  database: sql,
+  socialProviders: {
+    google: {
+      clientId: process.env.GOOGLE_CLIENT_ID!,
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
+    },
+  },
+})
 ```
 
-### 11. Test Connection
+Add to `.env.example`:
+```
+GOOGLE_CLIENT_ID=your-google-client-id
+GOOGLE_CLIENT_SECRET=your-google-client-secret
+```
+
+### 11. Install Dependencies
+
+```bash
+npm install postgres better-auth
+```
+
+### 12. Test Connection
 
 Create a simple test:
 ```typescript
@@ -174,7 +200,8 @@ Run: `npx tsx test-db.ts`
 - [ ] src/lib/db.ts client
 - [ ] .env.example and .env.local
 - [ ] Updated .gitignore
-- [ ] postgres package installed
+- [ ] Better Auth configured with Google OAuth
+- [ ] postgres + better-auth packages installed
 - [ ] Verified database connection
 
 ## Notes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,6 +131,22 @@ skill_router:
   # Maintenance
   - pattern: "/update|update oneshot|upgrade oneshot|check version"
     skill: auto-updater
+
+  # Infrastructure & Deployment
+  - pattern: "set up cloudflare|configure deploy|add database|add postgres|make this deployable|set up the stack"
+    skill: stack-setup
+    note: "Full Cloudflare + Postgres stack setup (Astro → CF Pages → Workers → Hyperdrive → Postgres on OCI)"
+```
+
+### Stack Quick Reference
+
+```
+Frontend: Cloudflare Pages (Astro)
+API:      Cloudflare Workers
+Database: Postgres on OCI via Hyperdrive
+Tunnel:   pg.omarsnewgroove.com → 100.126.13.70:5432
+Docs:     .claude/infrastructure/STACK.md
+Skill:    .claude/skills/stack-setup/SKILL.md
 ```
 
 **All other skills**: Available on-demand via `/skill-name` or explicit request. See INDEX.md.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@
 
 | Project Type | Trigger | Rules |
 |--------------|---------|-------|
-| Web app | `package.json` + `convex/` | `~/.claude/rules/web.md` |
+| Web app | `astro.config.*` or `wrangler.toml` | `~/.claude/rules/web.md` |
 | CLI | `setup.py` or `pyproject.toml` | `~/.claude/rules/cli.md` |
 | Service | `*.service` or long-running `*.py` | `~/.claude/rules/service.md` |
 | Generic | None detected | Core rules only |


### PR DESCRIPTION
## Summary

Added comprehensive infrastructure documentation and a new skill to guide setup of Omar's standard Cloudflare + Postgres stack for new projects.

## Changes

- **`.claude/infrastructure/STACK.md`** - Complete reference guide covering:
  - Architecture overview (Astro → Cloudflare Pages → Workers → Hyperdrive → Postgres on OCI)
  - Database connection details and common operations
  - Cloudflare Tunnel configuration
  - Per-project setup steps (database creation, Hyperdrive config, wrangler.toml)
  - Local development patterns
  - Deployment instructions
  - Backup procedures
  - Troubleshooting guide
  - Cost breakdown ($0 total)

- **`.claude/skills/stack-setup/SKILL.md`** - New skill for automated stack configuration:
  - Trigger patterns for when to activate the skill
  - 11-step action plan for setting up a new project
  - Prerequisites verification
  - Database client creation patterns
  - Environment file templates
  - Testing procedures
  - Output checklist

- **`AGENTS.md`** - Updated skill router:
  - Added pattern matching for stack setup triggers
  - Added quick reference section with stack architecture
  - Links to infrastructure docs and skill

## Implementation Details

The documentation establishes a zero-cost, vendor-independent stack using:
- Cloudflare's free tier (Pages, Workers, Hyperdrive, Tunnel)
- OCI's free tier (ARM compute with 24GB RAM)
- Self-hosted Postgres accessible via Tailscale + Cloudflare Tunnel

The skill provides step-by-step guidance for developers to replicate this setup across projects, with emphasis on local development via Tailscale and production deployment via Hyperdrive.

https://claude.ai/code/session_01Nsn9SHvg7ssoGxzRcEAJQm