### PR TITLE
Integrate Agent Lightning concepts into delegation tracing (v12.2)

### DIFF
--- a/.claude/commands/delegation-stats.md
+++ b/.claude/commands/delegation-stats.md
@@ -1,0 +1,80 @@
+---
+name: delegation-stats
+description: Aggregate delegation performance stats with reward-weighted metrics
+---
+
+# Delegation Stats (Agent Lightning-inspired)
+
+Aggregate delegation log data into performance insights. This is the "learning loop" — the prompt-level equivalent of Agent Lightning's training cycle.
+
+## Instructions
+
+1. Read `.claude/delegation-log.jsonl` (or `~/.claude/delegation-log.jsonl`)
+2. Parse all JSONL entries and compute aggregates:
+
+### By Agent Type
+For each agent_type, calculate:
+- Total delegations
+- Success rate (result=success / total)
+- Average reward (mean of reward field)
+- Average tool calls per delegation
+- Average duration
+- Most common tool sequences (top 3 patterns)
+
+### By Model
+For each model, calculate:
+- Total delegations
+- Average reward
+- Which agent types it was used with
+
+### Credit Patterns
+Identify:
+- **Best performers**: agent+model combos with highest avg reward
+- **Bottlenecks**: agent+model combos with lowest avg reward
+- **Efficient delegations**: high reward + low tool call count
+- **Wasteful delegations**: low reward + high tool call count
+
+3. Display results as a summary report.
+
+4. If user provided arguments:
+   - `agent:<type>` → detailed stats for one agent type
+   - `model:<name>` → detailed stats for one model
+   - `since:<date>` → filter to entries after date
+   - `recommendations` → generate routing recommendations based on data
+
+## Example Output
+
+```
+Delegation Performance Report
+═══════════════════════════════════════════════════════════════════
+
+By Agent Type                                          (last 30 days)
+─────────────────────────────────────────────────────────────────
+Agent         | Count | Success | Avg Reward | Avg Calls | Avg Time
+Explore       |    47 |   89%   |    0.82    |    6.2    |  14.3s
+Bash          |    23 |   96%   |    0.96    |    1.8    |   3.2s
+general       |    31 |   77%   |    0.71    |   12.1    |  38.4s
+Plan          |     8 |   88%   |    0.84    |    9.4    |  22.1s
+
+By Model
+─────────────────────────────────────────────────────────────────
+Model   | Count | Avg Reward | Best At             | Struggles With
+haiku   |    52 |    0.88    | search, formatting  | synthesis
+sonnet  |    41 |    0.79    | multi-step tasks    | deep reasoning
+opus    |    16 |    0.91    | architecture        | (small sample)
+
+Recommendations
+─────────────────────────────────────────────────────────────────
+• Explore+haiku: strong combo (0.88 reward). Keep using for search tasks.
+• general+sonnet: underperforming (0.71). Consider opus for complex research.
+• Bash+haiku: near-perfect (0.96). Ideal for all command execution.
+• Bottleneck: general-purpose agents averaging 12 tool calls. Consider
+  breaking large tasks into smaller delegations.
+```
+
+## Recommendations Mode (`recommendations`)
+
+When the user asks for recommendations, analyze the data and output actionable routing advice:
+- "For [task pattern], prefer [agent+model] (avg reward: X)"
+- "Avoid [agent+model] for [task pattern] (avg reward: X, consider [alternative])"
+- "High-value optimization: [specific change] would improve avg reward by ~X"

--- a/.claude/commands/delegation-trajectory.md
+++ b/.claude/commands/delegation-trajectory.md
@@ -1,0 +1,73 @@
+---
+name: delegation-trajectory
+description: View delegation trajectories — chains of spans grouped by session
+---
+
+# Delegation Trajectory Viewer
+
+Assemble delegation spans into session-level execution trajectories (inspired by Agent Lightning's trajectory concept).
+
+## Instructions
+
+1. Read `.claude/delegation-log.jsonl` (or `~/.claude/delegation-log.jsonl` if project-level doesn't exist)
+2. Parse the JSONL and group entries by `session_id`
+3. For each session (trajectory), display:
+   - Session ID
+   - Number of spans (delegations)
+   - Timeline: ordered sequence of agent_type → result
+   - Total tool calls across all spans
+   - Total duration
+   - Average reward score
+   - Tool sequence pattern (most common tool chains)
+
+4. If the user provided arguments, filter:
+   - `session:<id>` → show detailed view of one trajectory
+   - `last:<N>` → show only last N sessions
+   - `failures` → show only sessions with at least one failed span
+   - `patterns` → show recurring tool sequence patterns across all trajectories
+
+5. If no log file exists, say "No delegation log found. Spans are logged automatically via the SubagentStop hook."
+
+## Example Output
+
+```
+Delegation Trajectories (last 5 sessions)
+───────────────────────────────────────────────────────────────────
+Session abc123 (2026-02-13, 4 spans)
+  1. Explore [haiku]  → success (reward: 1.0, 8 calls, 12.3s)
+  2. Bash [haiku]     → success (reward: 1.0, 1 call, 2.1s)
+  3. general [sonnet] → partial (reward: 0.5, 15 calls, 45.2s)
+  4. Explore [haiku]  → success (reward: 1.0, 5 calls, 8.7s)
+  Trajectory: avg reward 0.88, 29 total calls, 68.3s total
+  Tool pattern: [Glob, Read, Grep] → [Bash] → [Read, Grep, WebSearch, Read...] → [Glob, Read]
+
+Session def456 (2026-02-13, 1 span)
+  1. Bash [haiku] → success (reward: 1.0, 2 calls, 3.4s)
+  Trajectory: avg reward 1.0, 2 total calls, 3.4s total
+...
+
+Summary: 5 sessions, 12 total spans, avg reward 0.91
+```
+
+## Detailed Session View (`session:<id>`)
+
+```
+Trajectory: abc123
+───────────────────────────────────────────────────────────────────
+Span 1: uuid-1234
+  Agent: Explore | Model: haiku | Result: success | Reward: 1.0
+  Input: "Find all error handling patterns in src/"
+  Output: "Found 12 error handling patterns across 5 files..."
+  Tools: [Glob, Read, Read, Grep, Read, Grep, Read, Read]
+  Duration: 12.3s
+
+Span 2: uuid-5678
+  Agent: Bash | Model: haiku | Result: success | Reward: 1.0
+  Input: "Run the test suite"
+  Output: "All 47 tests passed"
+  Tools: [Bash]
+  Duration: 2.1s
+...
+
+Credit flow: Span 1 (search) → Span 3 (implementation) had lowest reward — bottleneck
+```

--- a/.claude/hooks/delegation-log-hook.sh
+++ b/.claude/hooks/delegation-log-hook.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
-# SubagentStop hook: logs delegation events to .claude/delegation-log.jsonl
+# SubagentStop hook: logs delegation spans to .claude/delegation-log.jsonl
 # Deterministic — fires every time a subagent completes, no prompt needed.
+#
+# v12.2: Enriched with Agent Lightning-inspired span format
+#   - span_id for chaining into trajectories
+#   - session_id for grouping spans per session
+#   - task_input/task_output (truncated) for trace visibility
+#   - tool_sequence for action pattern analysis
+#   - reward heuristic (1.0=success, 0.5=partial, 0.0=failure)
 #
 # INSTALL: cp this to ~/.claude/delegation-log-hook.sh && chmod +x ~/.claude/delegation-log-hook.sh
 # Then add SubagentStop hook entry to ~/.claude/settings.json (see settings-patch.json)
@@ -12,8 +19,19 @@ agent_type=$(echo "$input" | jq -r '.agent_type // "unknown"')
 model=$(echo "$input" | jq -r '.model // "unknown"')
 tool_calls=$(echo "$input" | jq -r '.tool_calls_count // 0')
 duration_ms=$(echo "$input" | jq -r '.duration_ms // 0')
-# SubagentStop provides the subagent's final output
-output=$(echo "$input" | jq -r '.output // ""' | head -c 200)
+
+# Truncated input/output for trace visibility (Agent Lightning: span data)
+task_input=$(echo "$input" | jq -r '.task_prompt // .input // ""' | head -c 200)
+task_output=$(echo "$input" | jq -r '.output // ""' | head -c 200)
+
+# Tool sequence — ordered list of tools used (Agent Lightning: action sequence)
+tool_sequence=$(echo "$input" | jq -c '.tool_names // []')
+
+# Generate span_id (unique per delegation event)
+span_id=$(cat /proc/sys/kernel/random/uuid 2>/dev/null || date +%s%N | sha256sum | head -c 36)
+
+# Session ID from environment (groups spans into trajectories)
+session_id="${CLAUDE_SESSION_ID:-${CLAUDE_CODE_SESSION_ID:-unknown}}"
 
 # Determine log location: project .claude/ if it exists, else ~/.claude/
 if [ -d ".claude" ]; then
@@ -22,23 +40,49 @@ else
   log_file="$HOME/.claude/delegation-log.jsonl"
 fi
 
-# Determine result heuristic: if output contains error/fail keywords, mark partial
+# Determine result + reward heuristic (Agent Lightning: reward signal)
 result="success"
-if echo "$output" | grep -qiE '(error|failed|exception|timeout|could not|unable to)'; then
-  result="partial"
+reward=1.0
+if echo "$task_output" | grep -qiE '(error|failed|exception|timeout|could not|unable to)'; then
+  # Check if it's a complete failure vs partial
+  if echo "$task_output" | grep -qiE '(fatal|crash|aborted|panic|no results)'; then
+    result="failure"
+    reward=0.0
+  else
+    result="partial"
+    reward=0.5
+  fi
 fi
 
-# Build and append log entry
+# Build and append enriched log entry
 timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 jq -cn \
   --arg ts "$timestamp" \
+  --arg span "$span_id" \
+  --arg session "$session_id" \
   --arg agent "$agent_type" \
   --arg model "$model" \
   --arg result "$result" \
+  --argjson reward "$reward" \
   --argjson calls "${tool_calls:-0}" \
   --argjson dur "${duration_ms:-0}" \
-  --arg summary "$(echo "$output" | head -c 80)" \
-  '{timestamp: $ts, agent_type: $agent, model: $model, result: $result, tool_calls_count: $calls, duration_ms: $dur, summary: $summary}' \
+  --argjson tools "${tool_sequence:-[]}" \
+  --arg input "$(echo "$task_input" | head -c 200)" \
+  --arg output "$(echo "$task_output" | head -c 80)" \
+  '{
+    timestamp: $ts,
+    span_id: $span,
+    session_id: $session,
+    agent_type: $agent,
+    model: $model,
+    result: $result,
+    reward: $reward,
+    tool_calls_count: $calls,
+    duration_ms: $dur,
+    tool_sequence: $tools,
+    task_input: $input,
+    summary: $output
+  }' \
   >> "$log_file" 2>/dev/null
 
 # Always exit 0 — logging should never block the agent

--- a/docs/research/agent-lightning-integration.md
+++ b/docs/research/agent-lightning-integration.md
@@ -1,0 +1,81 @@
+# Agent Lightning Integration into ONE_SHOT
+
+**Date**: 2026-02-14
+**Builds on**: PR #5 (Intelligent Delegation v12.1, based on DeepMind arXiv:2602.11865)
+**Informed by**: Microsoft Agent Lightning (https://github.com/microsoft/agent-lightning)
+
+---
+
+## What is Agent Lightning?
+
+Agent Lightning (Microsoft, 2025) is an RL training framework for AI agents. It captures agent execution as structured **spans** (prompt → completion → tool calls → reward), assembles them into **trajectories**, applies **hierarchical credit assignment** to determine which steps mattered, and feeds that into a training loop.
+
+Its key insight: you can improve agent performance by recording what happened, scoring each step, and using that signal to route future decisions.
+
+## What We Took (Concepts, Not Code)
+
+We didn't install Agent Lightning. ONE_SHOT is a prompt framework, not an RL training pipeline. But the conceptual architecture maps cleanly onto our delegation system:
+
+| Agent Lightning | ONE_SHOT v12.2 | Notes |
+|-----------------|----------------|-------|
+| **Span** | Enriched JSONL entry in delegation-log | Each delegation event captures: span_id, session_id, agent_type, model, tool_sequence, task_input/output, reward |
+| **Trajectory** | `/delegation-trajectory` command | Groups spans by session_id into ordered execution paths |
+| **Credit assignment** | Heuristics in delegation.md | Output reuse = credit, last-before-failure = blame, low-cost success = efficient |
+| **LightningStore** | `.claude/delegation-log.jsonl` | Append-only JSONL — the central data exchange |
+| **Training loop** | `/delegation-stats` → rules update | Aggregated performance data informs future delegation routing (prompt-level "training") |
+
+## Why Adapt Instead of Adopt?
+
+1. **No GPU needed** — Agent Lightning's value is in its RL training loop, which requires model fine-tuning. We operate at the prompt level, so we extract the data architecture and skip the training.
+
+2. **No new dependencies** — Everything stays as shell scripts, JSONL, and markdown. No Python packages, no databases, no infrastructure.
+
+3. **Complementary to DeepMind framework** — PR #5 gave us the decision framework (assess → delegate → verify → escalate). Agent Lightning's concepts give us the data layer (trace → score → learn). Together: decide intelligently, then learn from what happened.
+
+## The Data Flow
+
+```
+Delegation happens
+    ↓
+SubagentStop hook fires (deterministic)
+    ↓
+Span written to delegation-log.jsonl
+  (span_id, session_id, agent, model, tools, reward)
+    ↓
+/delegation-log — view recent spans
+/delegation-trajectory — view session execution paths
+/delegation-stats — view aggregated performance + recommendations
+    ↓
+Human reads stats → adjusts delegation rules
+  (this is the "training loop" at prompt level)
+```
+
+## What This Enables
+
+### Today
+- See what every delegation did, not just whether it "succeeded"
+- Identify bottleneck delegations (low reward on the critical path)
+- Know which agent+model combos work best for which task types
+- Track delegation patterns across sessions
+
+### Future (if needed)
+- Automated routing: stats feed into assessment rules, closing the loop
+- Anomaly detection: flag sessions with unusual reward distributions
+- Cost optimization: identify where haiku suffices vs where opus is needed
+- If Agent Lightning adds a Claude provider, actual RL training on our span data
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `.claude/hooks/delegation-log-hook.sh` | Enriched with span_id, session_id, tool_sequence, reward |
+| `.claude/rules/delegation.md` | Added credit assignment heuristics, bumped to v12.2 |
+| `.claude/commands/delegation-trajectory.md` | New — trajectory assembly command |
+| `.claude/commands/delegation-stats.md` | New — reward-weighted performance stats |
+| `AGENTS.md` | Updated to v12.2, added new commands to router |
+
+## Sources
+
+- [Agent Lightning (GitHub)](https://github.com/microsoft/agent-lightning)
+- [Agent Lightning Blog Post](https://www.microsoft.com/en-us/research/blog/agent-lightning-adding-reinforcement-learning-to-ai-agents-without-code-rewrites/)
+- [Intelligent AI Delegation (arXiv:2602.11865)](https://arxiv.org/abs/2602.11865) — DeepMind paper that informed PR #5

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,179 @@
+# Plan: Integrate Agent Lightning Concepts into ONE_SHOT
+
+**Branch**: `claude/integrate-agent-lightning-QXAKk`
+**Depends on**: PR #5 (`claude/ai-delegation-research-3HdfP`) — AI Delegation v12.1
+**Sequence**: This merges AFTER PR #5
+
+---
+
+## Context
+
+**PR #5** added Intelligent Delegation (v12.1) based on DeepMind's paper:
+- Assessment protocol (complexity, criticality, uncertainty)
+- Verification after delegation
+- Fallback chains (3 attempts, escalate to human)
+- Audit logging via SubagentStop hook → `.claude/delegation-log.jsonl`
+- Trust calibration (Module 4, advisory — planned but not fully built)
+
+**Agent Lightning** (Microsoft) is an RL training framework for AI agents. Its core ideas:
+- **Spans**: Structured execution traces capturing prompts, completions, tool calls, rewards
+- **Trajectories**: Complete execution paths assembled from spans
+- **Credit assignment**: Evaluating which step contributed to outcome (hierarchical RL)
+- **LightningStore**: Central data exchange between execution and learning
+- **Training loop**: Continuous cycle of execute → trace → learn → improve
+
+**The bridge**: PR #5 gives us *assessment + logging*. Agent Lightning gives us *structured traces + learning*. Together they create a system that doesn't just log delegation events — it learns from them.
+
+---
+
+## What We Take From Agent Lightning (Concepts, Not Dependencies)
+
+We are NOT adding `pip install agentlightning` or building RL training. We're borrowing the conceptual architecture and applying it to ONE_SHOT's prompt-based system.
+
+| Agent Lightning Concept | ONE_SHOT Adaptation |
+|------------------------|---------------------|
+| **Spans** | Enrich delegation-log.jsonl entries with structured trace data (input context, output, tool sequence) |
+| **Trajectories** | Chain spans into session-level execution paths for pattern analysis |
+| **Credit assignment** | Per-step success scoring in delegation log → feeds trust calibration |
+| **LightningStore** | The `.claude/delegation-log.jsonl` + `.claude/delegation-stats.json` combo from PR #5 |
+| **Training loop** | `/delegation-stats` aggregation → rules update → better future decisions (prompt-level "training") |
+
+---
+
+## Implementation Steps
+
+### Step 1: Rebase on PR #5
+
+Before any work, rebase this branch on `claude/ai-delegation-research-3HdfP` so we have:
+- `.claude/rules/delegation.md`
+- `.claude/hooks/delegation-log-hook.sh`
+- `.claude/commands/delegation-log.md`
+- Updated AGENTS.md (v12.1)
+
+### Step 2: Enrich Span Format in Delegation Log
+
+Upgrade the delegation-log-hook.sh to capture richer span data inspired by Agent Lightning:
+
+**Current schema** (from PR #5):
+```json
+{"timestamp", "agent_type", "model", "result", "tool_calls_count", "duration_ms", "summary"}
+```
+
+**Enhanced schema** (Agent Lightning-inspired):
+```json
+{
+  "timestamp": "...",
+  "span_id": "uuid",
+  "session_id": "from-env",
+  "agent_type": "Explore",
+  "model": "haiku",
+  "task_input": "first 200 chars of task prompt",
+  "task_output": "first 200 chars of result",
+  "tool_sequence": ["Glob", "Read", "Read", "Grep"],
+  "tool_calls_count": 4,
+  "duration_ms": 12340,
+  "result": "success",
+  "assessment": {
+    "complexity": "medium",
+    "criticality": "low"
+  },
+  "reward": 1.0
+}
+```
+
+Key additions:
+- `span_id` — unique ID for chaining into trajectories
+- `session_id` — groups spans into session-level trajectories
+- `task_input` / `task_output` — the prompt and result (truncated)
+- `tool_sequence` — ordered list of tools used (the "action sequence" in RL terms)
+- `reward` — heuristic success score (1.0=success, 0.5=partial, 0.0=failure)
+
+**File**: Update `.claude/hooks/delegation-log-hook.sh`
+
+### Step 3: Add Trajectory Assembly
+
+Create a `/delegation-trajectory` command that chains spans by session_id into a full execution path. This shows:
+- The sequence of delegations in a session
+- Which succeeded/failed
+- Total tool calls and duration
+- The "critical path" (longest chain of dependent delegations)
+
+**File**: Create `.claude/commands/delegation-trajectory.md`
+
+### Step 4: Add Credit Assignment Heuristics
+
+Update `.claude/rules/delegation.md` to include credit assignment guidance:
+- When a multi-step task succeeds, which delegation was most valuable?
+- When it fails, which delegation was the bottleneck?
+- Simple heuristics: last-delegation-before-failure gets blame, delegations that produced reused outputs get credit
+
+This feeds into Module 4 (Trust Calibration) from PR #5 — the performance stats become reward-weighted rather than just success/fail counts.
+
+**File**: Update `.claude/rules/delegation.md` (add credit assignment section)
+
+### Step 5: Enhance Trust Calibration with Reward Signals
+
+Upgrade the planned `/delegation-stats` to use reward-weighted metrics:
+- Instead of just "Explore: 89% success rate", show "Explore: avg reward 0.82, best at codebase_search (0.94), worst at synthesis (0.61)"
+- This is the Agent Lightning "training loop" expressed as prompt-level learning
+
+**File**: Create/update `.claude/commands/delegation-stats.md`
+
+### Step 6: Document the Conceptual Bridge
+
+Create a research doc explaining how Agent Lightning concepts map to ONE_SHOT, why we adapted rather than adopted, and what this enables for future versions.
+
+**File**: Create `docs/research/agent-lightning-integration.md`
+
+### Step 7: Version Bump AGENTS.md to v12.2
+
+Update AGENTS.md to reference the new span format, trajectory assembly, and credit assignment. Tag as v12.2 (building on v12.1 from PR #5).
+
+**File**: Update `AGENTS.md`
+
+---
+
+## Files Changed Summary
+
+| Action | File | Step |
+|--------|------|------|
+| REBASE | Branch onto PR #5 | 1 |
+| UPDATE | `.claude/hooks/delegation-log-hook.sh` | 2 |
+| CREATE | `.claude/commands/delegation-trajectory.md` | 3 |
+| UPDATE | `.claude/rules/delegation.md` | 4 |
+| CREATE/UPDATE | `.claude/commands/delegation-stats.md` | 5 |
+| CREATE | `docs/research/agent-lightning-integration.md` | 6 |
+| UPDATE | `AGENTS.md` | 7 |
+
+---
+
+## What This Does NOT Do
+
+- No `pip install agentlightning` — we borrow concepts, not the library
+- No actual RL training — ONE_SHOT is a prompt framework, not a training framework
+- No GPU requirements — everything stays as JSONL + markdown rules
+- No breaking changes to PR #5 — purely additive
+- No new external dependencies of any kind
+
+---
+
+## Why This Matters
+
+PR #5 asks: "Should I delegate this? Did it work?"
+This branch asks: "What can I learn from how it went?"
+
+Together they create a delegation system that:
+1. **Assesses** before delegating (PR #5)
+2. **Traces** execution with structured spans (this branch)
+3. **Assigns credit** to individual steps (this branch)
+4. **Learns** from accumulated experience (this branch + PR #5 Module 4)
+5. **Verifies and escalates** on failure (PR #5)
+
+---
+
+## Sources
+
+- [Microsoft Agent Lightning (GitHub)](https://github.com/microsoft/agent-lightning)
+- [Agent Lightning: Adding RL to AI Agents (Microsoft Research Blog)](https://www.microsoft.com/en-us/research/blog/agent-lightning-adding-reinforcement-learning-to-ai-agents-without-code-rewrites/)
+- [Agent Lightning Documentation](https://microsoft.github.io/agent-lightning/latest/)
+- PR #5: AI Delegation Research (`claude/ai-delegation-research-3HdfP`)


### PR DESCRIPTION
## Summary

This PR adapts Microsoft Agent Lightning's conceptual architecture (spans, trajectories, credit assignment) into ONE_SHOT's delegation system. We enrich delegation logging with structured trace data, add trajectory assembly and performance analytics, and introduce credit assignment heuristics—all without new dependencies or breaking changes to v12.1.

Builds on PR #5 (Intelligent Delegation v12.1) by adding the data layer and learning loop that transforms raw delegation events into actionable performance insights.

## Key Changes

- **Enriched delegation span format** (`.claude/hooks/delegation-log-hook.sh`):
  - Added `span_id` and `session_id` for chaining spans into execution trajectories
  - Capture `task_input`, `task_output`, and `tool_sequence` for trace visibility
  - Compute `reward` heuristic (1.0=success, 0.5=partial, 0.0=failure) automatically
  - Maintains backward compatibility with v12.1 log entries

- **New trajectory assembly command** (`.claude/commands/delegation-trajectory.md`):
  - Groups spans by `session_id` into ordered execution paths
  - Shows critical path analysis, tool patterns, and aggregate metrics per session
  - Supports filtering by session, failures, or pattern analysis

- **New performance analytics command** (`.claude/commands/delegation-stats.md`):
  - Aggregates reward-weighted metrics by agent type and model
  - Identifies bottlenecks, efficient delegations, and best-performing combinations
  - Generates routing recommendations based on historical performance data

- **Credit assignment heuristics** (`.claude/rules/delegation.md`):
  - Documents how to evaluate which delegations contributed to outcomes
  - Maps signals (output reuse, failure points, efficiency) to credit/blame
  - Feeds into trust calibration for future delegation decisions

- **Updated documentation**:
  - New research doc (`docs/research/agent-lightning-integration.md`) explaining the conceptual bridge
  - Bumped `AGENTS.md` to v12.2 with new commands in skill router
  - Updated delegation protocol section with trace/learn phases

## Implementation Details

- **No new dependencies**: Everything stays as shell scripts, JSONL, and markdown
- **Deterministic logging**: Spans are logged via SubagentStop hook (not prompt-dependent)
- **Prompt-level learning**: `/delegation-stats` aggregation feeds back into rules, creating a feedback loop without RL training infrastructure
- **Backward compatible**: Existing v12.1 delegation logs remain queryable; new fields are additive

The span format and trajectory assembly enable the "training loop" concept from Agent Lightning—execute, trace, score, learn—expressed entirely at the prompt level.

https://claude.ai/code/session_019UtRYDpMcQZXGkTqGtbZ1T