### PR TITLE
Integrate Manus API worker into routing, models, and dispatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,12 +84,12 @@ python3 -m core.router.resolve --class implement_small --category coding
 | Task Class | Lane | Category | Workers |
 |---|---|---|---|
 | `plan` | premium | general | claude_code |
-| `implement_small` | cheap | coding | codex, gemini_cli, glm_claude |
+| `implement_small` | cheap | coding | codex, manus, gemini_cli, glm_claude |
 | `implement_medium` | balanced | coding | codex, gemini_cli |
-| `test_write` | cheap | coding | codex, gemini_cli, glm_claude |
+| `test_write` | cheap | coding | codex, manus, gemini_cli, glm_claude |
 | `review_diff` | premium | review | claude_code, codex |
-| `doc_draft` | cheap | writing | gemini_cli, codex, glm_claude |
-| `research` | research | research | gemini_cli, codex |
+| `doc_draft` | cheap | writing | manus, gemini_cli, codex, glm_claude |
+| `research` | research | research | manus, gemini_cli, codex |
 | `janitor_*` | janitor | general | free (openrouter/free) |
 
 Full config: `config/lanes.yaml`, `config/workers.yaml`
@@ -101,6 +101,7 @@ Full config: `config/lanes.yaml`, `config/workers.yaml`
 | Worker | Backend | Cost |
 |---|---|---|
 | `glm_claude` | ZAI / GLM-5-turbo | Free (until plan expiry) |
+| `manus` | Manus API v2 | Credits-based (event/daily/monthly/add-on/free order) |
 | `codex` | ChatGPT Plus | $20/mo subscription |
 | `gemini_cli` | Google API | Free (sign-in) |
 | `free` | openrouter/free | $0 always — janitor lane only |

--- a/config/lanes.yaml
+++ b/config/lanes.yaml
@@ -35,31 +35,31 @@ lanes:
     # codex: ChatGPT Plus $20/mo
     # glm_claude: ZAI GLM-5-turbo, claude CLI harness, free until 2026-05-02
     # claw_code: available but manual opt-in only (not in pool)
-    worker_pool: [gemini_cli, codex, glm_claude]
+    worker_pool: [codex, manus, gemini_cli, glm_claude]
     strategy: first_available
     fallback_lane: balanced
     max_parallel: 3
     category_preference:
-      coding: [codex, gemini_cli, glm_claude]
-      research: [gemini_cli, codex, glm_claude]
-      writing: [gemini_cli, codex, glm_claude]
-      review: [codex, glm_claude, gemini_cli]
-      general: [gemini_cli, codex, glm_claude]
+      coding: [codex, manus, gemini_cli, glm_claude]
+      research: [manus, gemini_cli, codex, glm_claude]
+      writing: [manus, gemini_cli, codex, glm_claude]
+      review: [codex, manus, glm_claude, gemini_cli]
+      general: [manus, gemini_cli, codex, glm_claude]
 
   research:
     planner: claude_code
     review_with: claude_code
-    worker_pool: [gemini_cli, codex]
+    worker_pool: [manus, gemini_cli, codex]
     search_backend: argus
     strategy: first_available
     fallback_lane: balanced
     max_parallel: 3
     category_preference:
-      coding: [codex, gemini_cli]
-      research: [gemini_cli, codex]
-      writing: [gemini_cli, codex]
-      review: [codex, gemini_cli]
-      general: [gemini_cli, codex]
+      coding: [codex, manus, gemini_cli]
+      research: [manus, gemini_cli, codex]
+      writing: [manus, gemini_cli, codex]
+      review: [codex, manus, gemini_cli]
+      general: [manus, gemini_cli, codex]
 
   janitor:
     planner: claude_code

--- a/config/models.yaml
+++ b/config/models.yaml
@@ -121,6 +121,36 @@ models:
     context_window: 1m
     latency_tier: medium
 
+  manus:manus-1.6-max:
+    lane: research
+    strengths: [research, agentic, long_horizon]
+    max_task_size: large
+    can_plan: false
+    can_review: true
+    tool_calling: true
+    context_window: 200k
+    latency_tier: medium
+
+  manus:manus-1.6:
+    lane: cheap
+    strengths: [coding, reasoning, agentic]
+    max_task_size: large
+    can_plan: false
+    can_review: true
+    tool_calling: true
+    context_window: 200k
+    latency_tier: medium
+
+  manus:manus-1.6-lite:
+    lane: cheap
+    strengths: [throughput, low_latency]
+    max_task_size: medium
+    can_plan: false
+    can_review: false
+    tool_calling: true
+    context_window: 128k
+    latency_tier: fast
+
   claude:sonnet:
     lane: premium
     strengths: [planning, orchestration, repo_synthesis]

--- a/config/workers.yaml
+++ b/config/workers.yaml
@@ -79,3 +79,16 @@ workers:
     plan_expires: null
     max_tokens: 1024
     timeout: 30
+
+  manus:
+    host: localhost
+    transport: local
+    role: worker
+    harness: direct_api
+    provider: manus
+    model: manus-1.6
+    api_base_url: https://api.manus.ai
+    auth_env: MANUS_API_KEY
+    notes:
+      - "Direct API worker via Manus v2 task lifecycle."
+      - "Profiles: manus-1.6-max, manus-1.6, manus-1.6-lite."

--- a/core/dispatch/run.py
+++ b/core/dispatch/run.py
@@ -20,6 +20,7 @@ import shlex
 import subprocess
 import sys
 import time
+import urllib.request
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from datetime import datetime, timezone
 from pathlib import Path
@@ -69,6 +70,7 @@ ZAI_MODELS = {"glm-5.1", "glm-5", "glm-5-turbo", "glm-4.7", "glm-4.6", "glm-4.5"
 ZAI_BASE_URL = "https://api.z.ai/api/coding/paas/v4"          # OpenAI-compatible (claw-code-agent)
 ZAI_ANTHROPIC_URL = "https://api.z.ai/api/anthropic"           # Anthropic-compatible (claude CLI)
 OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
+MANUS_BASE_URL = "https://api.manus.ai"
 
 
 def claw_code_command(prompt: str, output_file: str, model: str = "") -> list[str]:
@@ -180,7 +182,70 @@ def worker_available(worker: str) -> bool:
         if not _zai_plan_active():
             return False
         return True
+    elif worker == "manus":
+        has_key = bool(
+            os.environ.get("MANUS_API_KEY")
+            or subprocess.run(
+                ["bash", "-c", "secrets get MANUS_API_KEY 2>/dev/null"],
+                capture_output=True
+            ).stdout.strip()
+        )
+        return has_key
     return True
+
+
+def _manus_headers() -> dict[str, str]:
+    key = os.environ.get("MANUS_API_KEY", "")
+    if not key:
+        key = subprocess.run(
+            ["bash", "-c", "secrets get MANUS_API_KEY 2>/dev/null"],
+            capture_output=True, text=True
+        ).stdout.strip()
+    return {"Content-Type": "application/json", "x-manus-api-key": key}
+
+
+def _manus_request(method: str, path: str, payload: dict | None = None) -> dict:
+    url = f"{MANUS_BASE_URL}{path}"
+    body = json.dumps(payload or {}).encode("utf-8")
+    req = urllib.request.Request(url, data=body, method=method)
+    for k, v in _manus_headers().items():
+        req.add_header(k, v)
+    with urllib.request.urlopen(req, timeout=60) as resp:
+        raw = resp.read().decode("utf-8")
+    return json.loads(raw) if raw else {}
+
+
+def run_manus_task(prompt: str, output_file: str, model: str = "manus-1.6") -> tuple[int, str]:
+    """Create and poll a Manus task until completion; write raw response to output_file."""
+    try:
+        created = _manus_request("POST", "/v2/tasks", {"agentId": model, "input": prompt})
+        task_id = created.get("data", {}).get("id") or created.get("id")
+        if not task_id:
+            Path(output_file).write_text(json.dumps(created, indent=2))
+            return 1, "manus task create returned no id"
+
+        last = created
+        for _ in range(120):
+            time.sleep(5)
+            status_payload = _manus_request("GET", f"/v2/tasks/{task_id}", {})
+            last = status_payload
+            status = (
+                status_payload.get("data", {}).get("status")
+                or status_payload.get("status")
+                or ""
+            ).lower()
+            if status in {"completed", "succeeded", "done"}:
+                Path(output_file).write_text(json.dumps(status_payload, indent=2))
+                return 0, ""
+            if status in {"failed", "cancelled", "canceled", "error"}:
+                Path(output_file).write_text(json.dumps(status_payload, indent=2))
+                return 1, f"manus task {task_id} status={status}"
+
+        Path(output_file).write_text(json.dumps(last, indent=2))
+        return 1, "manus task polling timeout"
+    except Exception as e:
+        Path(output_file).write_text(json.dumps({"error": str(e)}, indent=2))
+        return 1, str(e)
 
 
 def _zai_plan_active() -> bool:
@@ -336,6 +401,32 @@ def parse_claw_code_output(output_file: str) -> dict:
     return result
 
 
+def parse_manus_output(output_file: str) -> dict:
+    result = {"worker": "manus", "messages": [], "errors": [], "usage": None}
+    if not os.path.exists(output_file):
+        result["errors"].append("No output file")
+        return result
+    try:
+        data = json.loads(Path(output_file).read_text() or "{}")
+        data_block = data.get("data", data)
+        text = (
+            data_block.get("output")
+            or data_block.get("result")
+            or data_block.get("message")
+            or json.dumps(data_block)
+        )
+        result["messages"].append(str(text))
+        usage = data_block.get("usage") or data.get("usage")
+        if usage:
+            result["usage"] = usage
+        status = (data_block.get("status") or data.get("status") or "").lower()
+        if status in {"failed", "cancelled", "canceled", "error"}:
+            result["errors"].append(f"manus status={status}")
+    except Exception as e:
+        result["errors"].append(str(e))
+    return result
+
+
 def get_config_sha() -> str:
     """Get the git SHA of config files for trace provenance."""
     try:
@@ -457,16 +548,22 @@ def dispatch_single(task: dict, output_dir: str) -> dict:
     elif worker == "glm_claude":
         model = task.get("model", "glm-5-turbo")
         cmd = glm_claude_command(prompt, output_file, model=model)
+    elif worker == "manus":
+        cmd = None
     else:
         return {"task_id": task_id, "worker": worker, "status": "failed",
                 "error": f"Unknown worker: {worker}"}
 
     # Execute
     try:
-        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=300,
-                             env=clean_env())
-        exit_code = proc.returncode
-        stderr = proc.stderr.strip() if proc.stderr else ""
+        if worker == "manus":
+            model = task.get("model", "manus-1.6")
+            exit_code, stderr = run_manus_task(prompt, output_file, model=model)
+        else:
+            proc = subprocess.run(cmd, capture_output=True, text=True, timeout=300,
+                                 env=clean_env())
+            exit_code = proc.returncode
+            stderr = proc.stderr.strip() if proc.stderr else ""
     except subprocess.TimeoutExpired:
         exit_code = -1
         stderr = "Timeout (300s)"
@@ -482,6 +579,8 @@ def dispatch_single(task: dict, output_dir: str) -> dict:
         parsed = parse_codex_output(output_file)
     elif worker in ("claw_code", "glm_claude"):
         parsed = parse_claw_code_output(output_file)
+    elif worker == "manus":
+        parsed = parse_manus_output(output_file)
     else:
         parsed = parse_gemini_output(output_file)
 

--- a/core/dispatch/run.py
+++ b/core/dispatch/run.py
@@ -21,6 +21,7 @@ import subprocess
 import sys
 import time
 import urllib.request
+import urllib.parse
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from datetime import datetime, timezone
 from pathlib import Path
@@ -204,10 +205,16 @@ def _manus_headers() -> dict[str, str]:
     return {"Content-Type": "application/json", "x-manus-api-key": key}
 
 
-def _manus_request(method: str, path: str, payload: dict | None = None) -> dict:
-    url = f"{MANUS_BASE_URL}{path}"
-    body = json.dumps(payload or {}).encode("utf-8")
-    req = urllib.request.Request(url, data=body, method=method)
+def _manus_request(
+    method: str,
+    path: str,
+    payload: dict | None = None,
+    query: dict | None = None
+) -> dict:
+    query_str = f"?{urllib.parse.urlencode(query)}" if query else ""
+    url = f"{MANUS_BASE_URL}{path}{query_str}"
+    body = None if method.upper() == "GET" else json.dumps(payload or {}).encode("utf-8")
+    req = urllib.request.Request(url, data=body, method=method.upper())
     for k, v in _manus_headers().items():
         req.add_header(k, v)
     with urllib.request.urlopen(req, timeout=60) as resp:
@@ -216,32 +223,68 @@ def _manus_request(method: str, path: str, payload: dict | None = None) -> dict:
 
 
 def run_manus_task(prompt: str, output_file: str, model: str = "manus-1.6") -> tuple[int, str]:
-    """Create and poll a Manus task until completion; write raw response to output_file."""
+    """Create and poll a Manus v2 task until completion; write raw response to output_file."""
     try:
-        created = _manus_request("POST", "/v2/tasks", {"agentId": model, "input": prompt})
-        task_id = created.get("data", {}).get("id") or created.get("id")
+        created = _manus_request(
+            "POST",
+            "/v2/task.create",
+            {
+                "agent_id": model,
+                "message": {
+                    "content": [
+                        {"type": "text", "text": prompt}
+                    ]
+                },
+            },
+        )
+        task_id = created.get("task_id") or created.get("task", {}).get("id")
         if not task_id:
             Path(output_file).write_text(json.dumps(created, indent=2))
             return 1, "manus task create returned no id"
 
-        last = created
+        last_detail = {}
+        last_messages = {}
         for _ in range(120):
             time.sleep(5)
-            status_payload = _manus_request("GET", f"/v2/tasks/{task_id}", {})
-            last = status_payload
-            status = (
-                status_payload.get("data", {}).get("status")
-                or status_payload.get("status")
-                or ""
-            ).lower()
-            if status in {"completed", "succeeded", "done"}:
-                Path(output_file).write_text(json.dumps(status_payload, indent=2))
+            detail_payload = _manus_request("GET", "/v2/task.detail", query={"task_id": task_id})
+            msgs_payload = _manus_request(
+                "GET", "/v2/task.listMessages",
+                query={"task_id": task_id, "order": "desc", "limit": 20}
+            )
+            last_detail = detail_payload
+            last_messages = msgs_payload
+            status = (detail_payload.get("task", {}).get("status") or "").lower()
+            if status == "stopped":
+                Path(output_file).write_text(json.dumps({
+                    "task_id": task_id,
+                    "detail": detail_payload,
+                    "messages": msgs_payload,
+                    "status": status,
+                }, indent=2))
                 return 0, ""
-            if status in {"failed", "cancelled", "canceled", "error"}:
-                Path(output_file).write_text(json.dumps(status_payload, indent=2))
+            if status == "error":
+                Path(output_file).write_text(json.dumps({
+                    "task_id": task_id,
+                    "detail": detail_payload,
+                    "messages": msgs_payload,
+                    "status": status,
+                }, indent=2))
                 return 1, f"manus task {task_id} status={status}"
+            if status == "waiting":
+                Path(output_file).write_text(json.dumps({
+                    "task_id": task_id,
+                    "detail": detail_payload,
+                    "messages": msgs_payload,
+                    "status": status,
+                }, indent=2))
+                return 1, f"manus task {task_id} waiting for input/confirmation"
 
-        Path(output_file).write_text(json.dumps(last, indent=2))
+        Path(output_file).write_text(json.dumps({
+            "task_id": task_id,
+            "detail": last_detail,
+            "messages": last_messages,
+            "status": (last_detail.get("task", {}).get("status") or "unknown"),
+        }, indent=2))
         return 1, "manus task polling timeout"
     except Exception as e:
         Path(output_file).write_text(json.dumps({"error": str(e)}, indent=2))
@@ -408,19 +451,25 @@ def parse_manus_output(output_file: str) -> dict:
         return result
     try:
         data = json.loads(Path(output_file).read_text() or "{}")
-        data_block = data.get("data", data)
-        text = (
-            data_block.get("output")
-            or data_block.get("result")
-            or data_block.get("message")
-            or json.dumps(data_block)
-        )
-        result["messages"].append(str(text))
-        usage = data_block.get("usage") or data.get("usage")
+        detail = data.get("detail", {})
+        messages_payload = data.get("messages", {})
+        messages = messages_payload.get("messages", [])
+        assistant_texts = []
+        for ev in messages:
+            if ev.get("type") == "assistant_message":
+                content = ev.get("assistant_message", {}).get("content")
+                if isinstance(content, str):
+                    assistant_texts.append(content)
+        if assistant_texts:
+            result["messages"].append("\n\n".join(assistant_texts))
+        else:
+            result["messages"].append(json.dumps(messages_payload or detail or data))
+
+        usage = detail.get("task", {}).get("credit_usage")
         if usage:
-            result["usage"] = usage
-        status = (data_block.get("status") or data.get("status") or "").lower()
-        if status in {"failed", "cancelled", "canceled", "error"}:
+            result["usage"] = {"credit_usage": usage}
+        status = (data.get("status") or detail.get("task", {}).get("status") or "").lower()
+        if status in {"error", "waiting"}:
             result["errors"].append(f"manus status={status}")
     except Exception as e:
         result["errors"].append(str(e))


### PR DESCRIPTION
### Motivation
- Add Manus as a first-class worker to expand cheap/research lanes with agentic, long-horizon, and high-throughput profiles.
- Enable dispatching to the Manus API so tasks can be executed via Manus agents when available.

### Description
- Updated docs and routing: added `manus` to the README routing/workers table and inserted `manus` into `cheap`/`research` lane worker pools and category preference ordering in `config/lanes.yaml`.
- Added Manus model entries to `config/models.yaml` with three variants (`manus-1.6-max`, `manus-1.6`, `manus-1.6-lite`).
- Added a `manus` worker definition to `config/workers.yaml` including API base and auth env configuration.
- Implemented Manus runtime support in `core/dispatch/run.py` by adding `MANUS_BASE_URL`, a `worker_available` check for `manus`, `_manus_headers` and `_manus_request` helpers, `run_manus_task` to create/poll tasks, `parse_manus_output` to interpret results, and dispatch logic to call Manus instead of a subprocess for `manus`-targeted tasks.

### Testing
- Ran the existing test suite with `pytest -q`, and the tests completed successfully.
- Ran linting via `flake8`, and no new lint errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f380b2f950832dac6a1a717f77947c)